### PR TITLE
work on index front

### DIFF
--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -41,7 +41,8 @@
 
 .navigation {
   width: 400px;
-  height: 70px;
+  height: 100px;
+  // height: 70px;
   background: rgb(255,255,255);
   position: relative;
   display: flex;

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -1,6 +1,7 @@
 .astrocrush {
   position: absolute;
-  top:9px;
+  top:19px;
+  // top:9px;
   padding-bottom: 5px;
   font-size: 32px;
   font-family: $headers-font;
@@ -11,10 +12,13 @@
 
 .profiles {
   position: absolute;
-  width: 390px;
+  width: 370px;
+  // width: 390px;
   height: 560px;
   padding: 10px;
-  top: 64px;
+  top: 80px;
+  // top: 64px;
+  left: 10px; // Ajout BOB
 }
 
 .profiles::before {
@@ -28,19 +32,25 @@
 
 .profile {
   position: absolute;
+  left:10px;
   left:0px;
   top:0px;
   width: 100%;
-  height: 696px;
+  height: 660px;
+  // height: 696px;
   border-radius: 12px;
   cursor:pointer;
 }
 
 .profile-image {
-  height: 696px;
-  width: 390px;
+  height: 660px;
+  // height: 696px;
+  width: 370px;
+  // width: 390px;
   border-radius: 12px;
-  box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+  box-shadow: 0 3px 6px rgba(0,0,0,0.1), 0 3px 6px rgba(0,0,0,0.1);
+  // box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+  // box-shadow: 0 10px 30px rgba(0,0,0,.1);
 }
 
 .profile-score-container {


### PR DESCRIPTION
- Rétrécissement de la largeur des cartes pour laisser apparaître une marge de 10px de part et d'autre
- Raccourcissement de la longueur des cartes (696 -> 660 px) pour élargir la barre de navigation et dans une moindre mesure l'entête Astrocrush
- Allègement du box shadow appliqué au cartes

PTF:
- les marges ne sont pas symétriques sur Safari (émulation depuis mac book) => vérifier le rendu sur iPhone 12
- retravailler le gradient sur la photo