### PR TITLE
Carousel fix

### DIFF
--- a/app/views/dashboard/_profile.html.erb
+++ b/app/views/dashboard/_profile.html.erb
@@ -24,13 +24,13 @@
   <%# Carousel text %>
   <div id="carouselProfileText" class="carousel slide" data-bs-touch="true">
     <div class="carousel-indicators">
-      <% personnality_report.each_with_index do |element, i| %>
-        <button type="button" data-bs-target="#carouselProfileText" data-bs-slide-to="<%= i %>" class=<%= "active" if i.zero? %> aria-current=<%= "true" if i.zero? %> aria-label="Slide <%= i + 1 %>"></button>
+      <% personnality_report.each_with_index do |element, index| %>
+        <button type="button" data-bs-target="#carouselProfileText" data-bs-slide-to="<%= index %>" class=<%= "active" if index.zero? %> aria-current=<%= "true" if index.zero? %> aria-label="Slide <%= index + 1 %>"></button>
       <% end %>
     </div>
     <div class="carousel-inner">
-      <% personnality_report.each_with_index do |element, i| %>
-        <div class="carousel-item <%= 'active' if i.zero? %>">
+      <% personnality_report.each_with_index do |element, index| %>
+        <div class="carousel-item <%= 'active' if index.zero? %>">
           <div class="sign-text">
             <p>
               <%= element %>.

--- a/app/views/users/dashboard.html.erb
+++ b/app/views/users/dashboard.html.erb
@@ -1,35 +1,17 @@
 <%# Carousel photos %>
 <div id="carouselPhotos" class="carousel slide" data-bs-touch="true">
   <div class="carousel-indicators">
-    <button type="button" data-bs-target="#carouselPhotos" data-bs-slide-to="0" class="active" aria-current="true" aria-label="Slide 1"></button>
-    <button type="button" data-bs-target="#carouselPhotos" data-bs-slide-to="1" aria-label="Slide 2"></button>
-    <button type="button" data-bs-target="#carouselPhotos" data-bs-slide-to="2" aria-label="Slide 3"></button>
+    <% current_user.photos.each_with_index do |photo, index| %>
+      <button type="button" data-bs-target="#carouselPhotos" data-bs-slide-to="<%= index %>" class=<%= "active" if index.zero? %> aria-current=<%= "true" if index.zero? %> aria-label="Slide <%= index + 1 %>"></button>
+    <% end %>
   </div>
   <div class="carousel-inner">
-    <% if current_user.photos.count == 1 %>
-      <div class="carousel-item active">
-        <div class="detailed-profile-image" style="background-image: linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.3)), url('<%= cl_image_path current_user.photos[0].key, height: 450, width: 390, crop: :fill %>')"></div>
-      </div>
-    <% else %>
-      <div class="carousel-item active">
-          <div class="detailed-profile-image" style="background-image: linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.3)), url('<%= cl_image_path current_user.photos[0].key, height: 450, width: 390, crop: :fill %>')"></div>
-        </div>
-      <div class="carousel-item">
-        <div class="detailed-profile-image" style="background-image: linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.3)), url('<%= cl_image_path current_user.photos[1].key, height: 450, width: 390, crop: :fill %>')"></div>
-      </div>
-      <div class="carousel-item">
-        <div class="detailed-profile-image" style="background-image: linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.3)), url('<%= cl_image_path current_user.photos[2].key, height: 450, width: 390, crop: :fill %>')"></div>
+    <% current_user.photos.each_with_index do |photo, index| %>
+      <div class="carousel-item <%= "active" if index.zero? %>">
+        <div class="detailed-profile-image" style="background-image: linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.3)), url('<%= cl_image_path current_user.photos[index].key, height: 450, width: 410, crop: :fill %>')"></div>
       </div>
     <% end %>
   </div>
-  <%# <button class="carousel-control-prev" type="button" data-bs-target="#carouselPhotos" data-bs-slide="prev">
-    <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-    <span class="visually-hidden">Previous</span>
-  </button>
-  <button class="carousel-control-next" type="button" data-bs-target="#carouselPhotos" data-bs-slide="next">
-    <span class="carousel-control-next-icon" aria-hidden="true"></span>
-    <span class="visually-hidden">Next</span>
-  </button> %>
 </div>
 
 <div class="container detailed-profile-content">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -4,9 +4,6 @@
     <% @mate.photos.each_with_index do |photo, index| %>
       <button type="button" data-bs-target="#carouselPhotos" data-bs-slide-to="<%= index %>" class=<%= "active" if index.zero? %> aria-current=<%= "true" if index.zero? %> aria-label="Slide <%= index + 1 %>"></button>
     <% end %>
-      <%# <button type="button" data-bs-target="#carouselPhotos" data-bs-slide-to="0" class="active" aria-current="true" aria-label="Slide 1"></button>
-      <button type="button" data-bs-target="#carouselPhotos" data-bs-slide-to="1" aria-label="Slide 2"></button>
-      <button type="button" data-bs-target="#carouselPhotos" data-bs-slide-to="2" aria-label="Slide 3"></button> %>
   </div>
   <div class="carousel-inner">
     <% @mate.photos.each_with_index do |photo, index| %>
@@ -14,24 +11,7 @@
         <div class="detailed-profile-image" style="background-image: linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.3)), url('<%= cl_image_path @mate.photos[index].key, height: 450, width: 410, crop: :fill %>')"></div>
       </div>
     <% end %>
-    <%# <div class="carousel-item active"> %>
-      <%# <% <div class="detailed-profile-image" style="background-image: linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.3)), url('<%= cl_image_path @mate.photos[0].key, height: 450, width: 410, crop: :fill')"></div> %>
-    <%# </div> %>
-    <%# <div class="carousel-item"> %>
-      <%# <% <div class="detailed-profile-image" style="background-image: linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.3)), url('<%= cl_image_path @mate.photos[1].key, height: 450, width: 410, crop: :fill')"></div> %>
-    <%# </div> %>
-    <%# <div class="carousel-item"> %>
-      <%# <% <div class="detailed-profile-image" style="background-image: linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.3)), url('<%= cl_image_path @mate.photos[2].key, height: 450, width: 410, crop: :fill')"></div> %>
-    <%# </div> %>
   </div>
-  <%# <button class="carousel-control-prev" type="button" data-bs-target="#carouselPhotos" data-bs-slide="prev">
-    <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-    <span class="visually-hidden">Previous</span>
-  </button>
-  <button class="carousel-control-next" type="button" data-bs-target="#carouselPhotos" data-bs-slide="next">
-    <span class="carousel-control-next-icon" aria-hidden="true"></span>
-    <span class="visually-hidden">Next</span>
-  </button> %>
 </div>
 
 <%# <div class="background"> %>
@@ -134,17 +114,17 @@
           </div>
         </div>
 
-        <% sun_report = current_user.mate_sun_reports[params[:id].to_i]['report'].split(".") %>
         <%# Carousel text %>
+        <% sun_report = current_user.mate_sun_reports[params[:id].to_i]['report'].split(".") %>
         <div id="carouselText" class="carousel pb-3 carousel-dark slide" data-bs-touch="true">
           <div class="carousel-indicators">
-            <% sun_report.each_with_index do |element, i| %>
-              <button type="button" data-bs-target="#carouselText" data-bs-slide-to="<%= i %>" class=<%= "active" if i.zero? %> aria-current=<%= "true" if i.zero? %> aria-label="Slide <%= i + 1 %>"></button>
+            <% sun_report.each_with_index do |element, index| %>
+              <button type="button" data-bs-target="#carouselText" data-bs-slide-to="<%= index %>" class=<%= "active" if index.zero? %> aria-current=<%= "true" if index.zero? %> aria-label="Slide <%= index + 1 %>"></button>
             <% end %>
           </div>
           <div class="carousel-inner">
-            <% sun_report.each_with_index do |element, i| %>
-              <div class="carousel-item <%= 'active' if i.zero? %>">
+            <% sun_report.each_with_index do |element, index| %>
+              <div class="carousel-item <%= 'active' if index.zero? %>">
                 <div class="sign-text">
                   <p>
                     <%= element %>.
@@ -152,14 +132,6 @@
                 </div>
               </div>
             <% end %>
-          <%# <button class="carousel-control-prev" type="button" data-bs-target="#carouselText" data-bs-slide="prev">
-            <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-            <span class="visually-hidden">Previous</span>
-          </button>
-          <button class="carousel-control-next" type="button" data-bs-target="#carouselText" data-bs-slide="next">
-            <span class="carousel-control-next-icon" aria-hidden="true"></span>
-            <span class="visually-hidden">Next</span>
-          </button> %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Les carousels photos (sur show et dashboard) ont été ajustés pour afficher un nombre de photos et d'indicateurs variant en fonction du nombre uploadé par l'utilisateur. 
Les carousels textes (sur show et astroboard) fonctionnaient déjà selon cette logique. Je me suis contenté d'uniformiser leur syntaxe.